### PR TITLE
fix: ensure .surql schema files are copied to dist during build

### DIFF
--- a/packages/nx-surrealdb/project.json
+++ b/packages/nx-surrealdb/project.json
@@ -53,6 +53,11 @@
             "input": "{projectRoot}/src",
             "glob": "**/files/**",
             "output": "src"
+          },
+          {
+            "input": "{projectRoot}/src",
+            "glob": "**/*.surql",
+            "output": "src"
           }
         ]
       },


### PR DESCRIPTION
## Summary
- Add glob pattern to copy all .surql files from src to dist during build
- Resolves "Schema file not found" error when running nx-surrealdb executors
- Fixes missing system_migrations.surql and other schema files in distribution

## Problem
The status executor was failing with:
```
Schema file not found: /path/to/node_modules/@deepbrainspace/nx-surrealdb/dist/src/schema/system_migrations.surql
```

## Solution
Added asset glob pattern in project.json build configuration:
```json
{
  "input": "{projectRoot}/src",
  "glob": "**/*.surql",
  "output": "src"
}
```

## Test plan
- [x] Build package and verify .surql files are copied to dist
- [ ] Test status executor after merge and release
- [ ] Verify all other executors work correctly

🤖 Generated with [Claude Code](https://claude.ai/code)