### PR TITLE
fix: configure proper version resolvers for release groups

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,6 +39,14 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
+      - name: Build affected packages
+        if: steps.detect.outputs.has-packages == 'true'
+        run: |
+          echo "🔨 Building affected packages before release..."
+          PACKAGES=$(echo '${{ steps.detect.outputs.packages }}' | jq -r '.[]' | tr '\n' ',' | sed 's/,$//')
+          echo "📦 Building packages: $PACKAGES"
+          nx run-many --target=build --projects=$PACKAGES --parallel=5
+
       - name: Release packages
         if: steps.detect.outputs.has-packages == 'true'
         run: |

--- a/nx.json
+++ b/nx.json
@@ -96,7 +96,12 @@
     "groups": {
       "nx-plugins": {
         "projects": ["nx-*"],
-        "version": {},
+        "version": {
+          "generatorOptions": {
+            "currentVersionResolver": "git-tag",
+            "fallbackCurrentVersionResolver": "disk"
+          }
+        },
         "changelog": {
           "automaticFromRef": true,
           "projectChangelogs": {
@@ -109,7 +114,9 @@
       "rust-packages": {
         "projects": ["claude-code-toolkit"],
         "version": {
+          "generator": "@goodiebag/nx-rust:release-version",
           "generatorOptions": {
+            "currentVersionResolver": "git-tag",
             "fallbackCurrentVersionResolver": "disk"
           }
         },

--- a/nx.json
+++ b/nx.json
@@ -114,7 +114,7 @@
       "rust-packages": {
         "projects": ["claude-code-toolkit"],
         "version": {
-          "generator": "@goodiebag/nx-rust:release-version",
+          "versionActions": "@goodiebag/nx-rust/release",
           "generatorOptions": {
             "currentVersionResolver": "git-tag",
             "fallbackCurrentVersionResolver": "disk"

--- a/packages/nx-rust/CHANGELOG.md
+++ b/packages/nx-rust/CHANGELOG.md
@@ -1,3 +1,18 @@
+## 3.0.0-alpha.0 (2025-06-20)
+
+### 🚀 Features
+
+- enhance release workflow and prepare nx-rust v3.0.0 ([#24](https://github.com/deepbrainspace/goodiebag/pull/24))
+
+### 🩹 Fixes
+
+- configure proper version resolvers for release groups ([34abfe3](https://github.com/deepbrainspace/goodiebag/commit/34abfe3))
+
+### ❤️ Thank You
+
+- nayeem.ai @wizardsupreme
+- wizard supreme @wizardsupreme
+
 ## [3.0.0] - 2024-12-20
 
 ### Added

--- a/packages/nx-rust/CHANGELOG.md
+++ b/packages/nx-rust/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 3.0.0-alpha.1 (2025-06-20)
+
+### 🩹 Fixes
+
+- resolve workspace path issue in nx-rust release-version tests ([c008093](https://github.com/deepbrainspace/goodiebag/commit/c008093))
+
+### ❤️ Thank You
+
+- wizard supreme @wizardsupreme
+
 ## 3.0.0-alpha.0 (2025-06-20)
 
 ### 🚀 Features

--- a/packages/nx-rust/package.json
+++ b/packages/nx-rust/package.json
@@ -1,10 +1,10 @@
 {
   "name": "@goodiebag/nx-rust",
-  "version": "3.0.0-alpha.0",
-  "main": "./src/index.js",
+  "version": "3.0.0-alpha.1",
+  "main": "./dist/src/index.js",
   "exports": {
-    ".": "./src/index.js",
-    "./release": "./src/release/index.js"
+    ".": "./dist/src/index.js",
+    "./release": "./dist/src/release/index.js"
   },
   "repository": {
     "type": "git",
@@ -18,8 +18,8 @@
   "generators": "./generators.json",
   "executors": "./executors.json",
   "dependencies": {
-    "@nx/devkit": ">= 19 < 21",
     "@ltd/j-toml": "1.38.0",
+    "@nx/devkit": ">= 19 < 21",
     "npm-run-path": "^4.0.1",
     "picocolors": "^1.1.1",
     "semver": "7.5.4",
@@ -27,6 +27,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.8.0",
+    "@goodiebag/nx-rust": "3.0.0-alpha",
     "@nx/eslint": "^21.2.0",
     "@nx/jest": "^21.2.0",
     "@nx/plugin": "^21.2.0",

--- a/packages/nx-rust/package.json
+++ b/packages/nx-rust/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@goodiebag/nx-rust",
-  "version": "1.0.0",
+  "version": "3.0.0",
   "main": "./src/index.js",
   "repository": {
     "type": "git",

--- a/packages/nx-rust/package.json
+++ b/packages/nx-rust/package.json
@@ -1,13 +1,20 @@
 {
   "name": "@goodiebag/nx-rust",
-  "version": "3.0.0",
+  "version": "3.0.0-alpha.0",
   "main": "./src/index.js",
+  "exports": {
+    ".": "./src/index.js",
+    "./release": "./src/release/index.js"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/deepbrainspace/goodiebag.git"
   },
   "license": "MIT",
   "private": false,
+  "publishConfig": {
+    "access": "public"
+  },
   "generators": "./generators.json",
   "executors": "./executors.json",
   "dependencies": {

--- a/packages/nx-rust/package.json
+++ b/packages/nx-rust/package.json
@@ -4,7 +4,8 @@
   "main": "./dist/src/index.js",
   "exports": {
     ".": "./dist/src/index.js",
-    "./release": "./dist/src/release/index.js"
+    "./release": "./dist/src/release/index.js",
+    "./package.json": "./package.json"
   },
   "repository": {
     "type": "git",

--- a/packages/nx-rust/package.json
+++ b/packages/nx-rust/package.json
@@ -1,10 +1,10 @@
 {
   "name": "@goodiebag/nx-rust",
   "version": "3.0.0-alpha.1",
-  "main": "./dist/src/index.js",
+  "main": "./src/index.js",
   "exports": {
-    ".": "./dist/src/index.js",
-    "./release": "./dist/src/release/index.js",
+    ".": "./src/index.js",
+    "./release": "./src/release/index.js",
     "./package.json": "./package.json"
   },
   "repository": {

--- a/packages/nx-rust/src/index.ts
+++ b/packages/nx-rust/src/index.ts
@@ -8,4 +8,8 @@ const nxPlugin: NxPlugin = {
   createNodesV2,
 };
 
-export = nxPlugin;
+// Default export for NX plugin
+export default nxPlugin;
+
+// Export release functionality for NX Release system
+export * from './release';

--- a/packages/nx-rust/src/release/index.ts
+++ b/packages/nx-rust/src/release/index.ts
@@ -1,0 +1,2 @@
+export { default } from './version-actions';
+export { afterAllProjectsVersioned } from './version-actions';

--- a/packages/nx-rust/src/release/version-actions.ts
+++ b/packages/nx-rust/src/release/version-actions.ts
@@ -1,0 +1,303 @@
+import {
+  ProjectGraph,
+  ProjectGraphProjectNode,
+  Tree,
+  joinPathFragments,
+  workspaceRoot,
+} from '@nx/devkit';
+import { execSync } from 'node:child_process';
+import { relative } from 'node:path';
+import { existsSync } from 'node:fs';
+import { VersionActions } from 'nx/src/command-line/release/version/version-actions';
+import { ReleaseGroupWithName } from 'nx/src/command-line/release/config/filter-release-groups';
+import { FinalConfigForProject } from 'nx/src/command-line/release/version/release-group-processor';
+import { NxReleaseVersionConfiguration } from 'nx/src/config/nx-json';
+import { parseCargoToml, stringifyCargoToml } from '../utils/toml';
+
+export default class RustVersionActions extends VersionActions {
+  validManifestFilenames = ['Cargo.toml'];
+
+  constructor(
+    public releaseGroup: ReleaseGroupWithName,
+    public projectGraphNode: ProjectGraphProjectNode,
+    public finalConfigForProject: FinalConfigForProject
+  ) {
+    super(releaseGroup, projectGraphNode, finalConfigForProject);
+  }
+
+  async readCurrentVersionFromSourceManifest(tree: Tree): Promise<{
+    currentVersion: string;
+    manifestPath: string;
+  } | null> {
+    const packageRoot = this.projectGraphNode.data.root;
+    const cargoTomlPath = joinPathFragments(packageRoot, 'Cargo.toml');
+    const workspaceRelativeCargoTomlPath = relative(workspaceRoot, cargoTomlPath);
+
+    if (!tree.exists(cargoTomlPath)) {
+      throw new Error(
+        `The project "${this.projectGraphNode.name}" does not have a Cargo.toml available at ${workspaceRelativeCargoTomlPath}.
+
+To fix this you will either need to add a Cargo.toml file at that location, or configure "release" within your nx.json to exclude "${this.projectGraphNode.name}" from the current release group, or amend the packageRoot configuration to point to where the Cargo.toml should be.`
+      );
+    }
+
+    const cargoTomlContents = tree.read(cargoTomlPath)!.toString('utf-8');
+    const data = parseCargoToml(cargoTomlContents);
+    
+    if (!data.package?.version) {
+      throw new Error(
+        `Unable to determine the current version for project "${this.projectGraphNode.name}" from ${workspaceRelativeCargoTomlPath}, please ensure that the "version" field is set within the [package] section of the Cargo.toml file`
+      );
+    }
+
+    return {
+      currentVersion: data.package.version,
+      manifestPath: cargoTomlPath,
+    };
+  }
+
+  async readCurrentVersionFromRegistry(
+    tree: Tree,
+    currentVersionResolverMetadata: NxReleaseVersionConfiguration['currentVersionResolverMetadata']
+  ): Promise<{
+    currentVersion: string | null;
+    logText: string;
+  } | null> {
+    const packageRoot = this.projectGraphNode.data.root;
+    const cargoTomlPath = joinPathFragments(packageRoot, 'Cargo.toml');
+    const cargoTomlContents = tree.read(cargoTomlPath)!.toString('utf-8');
+    const data = parseCargoToml(cargoTomlContents);
+    const packageName = data.package?.name;
+
+    if (!packageName) {
+      throw new Error(
+        `Unable to determine package name for project "${this.projectGraphNode.name}" from Cargo.toml`
+      );
+    }
+
+    const metadata = currentVersionResolverMetadata;
+    const registryUrl = typeof metadata?.registry === 'string' ? metadata.registry : 'https://crates.io';
+    
+    try {
+      // Use cargo search to check if package exists on registry
+      const result = execSync(`cargo search "${packageName}" --limit 1 --registry crates-io`, {
+        encoding: 'utf-8',
+        stdio: 'pipe',
+      });
+      
+      // Parse cargo search output: "package_name = "version"    # description"
+      const match = result.match(/^.*?\s*=\s*"([^"]+)"/);
+      if (match && match[1]) {
+        return {
+          currentVersion: match[1],
+          logText: `registry=${registryUrl}`,
+        };
+      }
+      
+      return {
+        currentVersion: null,
+        logText: `registry=${registryUrl} (package not found)`,
+      };
+    } catch (error) {
+      return {
+        currentVersion: null,
+        logText: `registry=${registryUrl} (error: ${error})`,
+      };
+    }
+  }
+
+  async readCurrentVersionOfDependency(
+    tree: Tree,
+    projectGraph: ProjectGraph,
+    dependencyProjectName: string
+  ): Promise<{
+    currentVersion: string | null;
+    dependencyCollection: string | null;
+  }> {
+    const packageRoot = this.projectGraphNode.data.root;
+    const cargoTomlPath = joinPathFragments(packageRoot, 'Cargo.toml');
+    const cargoTomlContents = tree.read(cargoTomlPath)!.toString('utf-8');
+    const data = parseCargoToml(cargoTomlContents);
+
+    // Get the package name of the dependency project
+    const dependencyProject = projectGraph.nodes[dependencyProjectName];
+    if (!dependencyProject) {
+      throw new Error(
+        `Unable to find dependency project "${dependencyProjectName}" in project graph`
+      );
+    }
+
+    const dependencyCargoTomlPath = joinPathFragments(dependencyProject.data.root, 'Cargo.toml');
+    const dependencyCargoTomlContents = tree.read(dependencyCargoTomlPath)!.toString('utf-8');
+    const dependencyData = parseCargoToml(dependencyCargoTomlContents);
+    const dependencyPackageName = dependencyData.package?.name;
+
+    if (!dependencyPackageName) {
+      throw new Error(
+        `Unable to determine package name for dependency project "${dependencyProjectName}"`
+      );
+    }
+
+    // Check both dependencies and dev-dependencies
+    const dependencies = data.dependencies || {};
+    const devDependencies = data['dev-dependencies'] || {};
+    
+    let depData = dependencies[dependencyPackageName];
+    let dependencyCollection: string | null = 'dependencies';
+    
+    if (!depData) {
+      depData = devDependencies[dependencyPackageName];
+      dependencyCollection = depData ? 'dev-dependencies' : null;
+    }
+    
+    if (!depData) {
+      return {
+        currentVersion: null,
+        dependencyCollection: null,
+      };
+    }
+
+    // Handle different dependency formats
+    let currentVersion: string | null = null;
+    if (typeof depData === 'string') {
+      currentVersion = depData;
+    } else if (typeof depData === 'object' && (depData as Record<string, unknown>).version) {
+      currentVersion = (depData as Record<string, unknown>).version as string;
+    }
+
+    return {
+      currentVersion,
+      dependencyCollection,
+    };
+  }
+
+  async updateProjectVersion(
+    tree: Tree,
+    newVersion: string
+  ): Promise<string[]> {
+    const packageRoot = this.projectGraphNode.data.root;
+    const cargoTomlPath = joinPathFragments(packageRoot, 'Cargo.toml');
+    const workspaceRelativeCargoTomlPath = relative(workspaceRoot, cargoTomlPath);
+    
+    const cargoTomlContents = tree.read(cargoTomlPath)!.toString('utf-8');
+    const data = parseCargoToml(cargoTomlContents);
+
+    if (!data.package) {
+      throw new Error(
+        `Unable to update version for project "${this.projectGraphNode.name}": no [package] section found in Cargo.toml`
+      );
+    }
+
+    data.package.version = newVersion;
+    tree.write(cargoTomlPath, stringifyCargoToml(data));
+
+    return [
+      `✍️  New version ${newVersion} written to ${workspaceRelativeCargoTomlPath}`,
+    ];
+  }
+
+  async updateProjectDependencies(
+    tree: Tree,
+    projectGraph: ProjectGraph,
+    dependenciesToUpdate: Record<string, string>
+  ): Promise<string[]> {
+    const packageRoot = this.projectGraphNode.data.root;
+    const cargoTomlPath = joinPathFragments(packageRoot, 'Cargo.toml');
+    const cargoTomlContents = tree.read(cargoTomlPath)!.toString('utf-8');
+    const data = parseCargoToml(cargoTomlContents);
+
+    let numUpdated = 0;
+    const logMessages: string[] = [];
+
+    for (const [dependencyProjectName, newVersion] of Object.entries(dependenciesToUpdate)) {
+      // Get the package name of the dependency project
+      const dependencyProject = projectGraph.nodes[dependencyProjectName];
+      if (!dependencyProject) {
+        continue;
+      }
+
+      const dependencyCargoTomlPath = joinPathFragments(dependencyProject.data.root, 'Cargo.toml');
+      const dependencyCargoTomlContents = tree.read(dependencyCargoTomlPath)!.toString('utf-8');
+      const dependencyData = parseCargoToml(dependencyCargoTomlContents);
+      const dependencyPackageName = dependencyData.package?.name;
+
+      if (!dependencyPackageName) {
+        continue;
+      }
+
+      // Update in dependencies section
+      if (data.dependencies && data.dependencies[dependencyPackageName]) {
+        if (typeof data.dependencies[dependencyPackageName] === 'string') {
+          data.dependencies[dependencyPackageName] = newVersion;
+          numUpdated++;
+        } else if (typeof data.dependencies[dependencyPackageName] === 'object') {
+          (data.dependencies[dependencyPackageName] as Record<string, unknown>).version = newVersion;
+          numUpdated++;
+        }
+      }
+
+      // Update in dev-dependencies section
+      if (data['dev-dependencies'] && data['dev-dependencies'][dependencyPackageName]) {
+        if (typeof data['dev-dependencies'][dependencyPackageName] === 'string') {
+          data['dev-dependencies'][dependencyPackageName] = newVersion;
+          numUpdated++;
+        } else if (typeof data['dev-dependencies'][dependencyPackageName] === 'object') {
+          (data['dev-dependencies'][dependencyPackageName] as Record<string, unknown>).version = newVersion;
+          numUpdated++;
+        }
+      }
+    }
+
+    if (numUpdated > 0) {
+      tree.write(cargoTomlPath, stringifyCargoToml(data));
+      const depText = numUpdated === 1 ? 'dependency' : 'dependencies';
+      logMessages.push(
+        `✍️  Updated ${numUpdated} ${depText} in ${relative(workspaceRoot, cargoTomlPath)}`
+      );
+    }
+
+    return logMessages;
+  }
+}
+
+/**
+ * Function called after all projects have been versioned.
+ * Updates Cargo.lock file if it exists.
+ */
+export async function afterAllProjectsVersioned(
+  cwd: string,
+  opts: {
+    dryRun?: boolean;
+    verbose?: boolean;
+    rootVersionActionsOptions?: Record<string, unknown>;
+  }
+): Promise<{
+  changedFiles: string[];
+  deletedFiles: string[];
+}> {
+  const changedFiles: string[] = [];
+  
+  // Update Cargo.lock file if it exists
+  const cargoLockPath = joinPathFragments(cwd, 'Cargo.lock');
+  if (existsSync(cargoLockPath)) {
+    try {
+      if (!opts.dryRun) {
+        // Run cargo update to refresh the lock file
+        execSync('cargo update', {
+          cwd,
+          stdio: 'pipe',
+        });
+      }
+      changedFiles.push('Cargo.lock');
+    } catch (error) {
+      if (opts.verbose) {
+        console.warn('[nx-rust] Failed to update Cargo.lock:', error);
+      }
+    }
+  }
+
+  return {
+    changedFiles,
+    deletedFiles: [],
+  };
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -102,6 +102,9 @@ importers:
       '@eslint/js':
         specifier: ^9.8.0
         version: 9.29.0
+      '@goodiebag/nx-rust':
+        specifier: 3.0.0-alpha
+        version: 3.0.0-alpha(nx@21.2.0(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.17))(@swc/types@0.1.23)(typescript@5.8.3))(@swc/core@1.5.29(@swc/helpers@0.5.17)))
       '@nx/eslint':
         specifier: ^21.2.0
         version: 21.2.0(@babel/traverse@7.27.4)(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.17))(@swc/types@0.1.23)(typescript@5.8.3))(@swc/core@1.5.29(@swc/helpers@0.5.17))(@zkochan/js-yaml@0.0.7)(eslint@9.29.0)(nx@21.2.0(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.17))(@swc/types@0.1.23)(typescript@5.8.3))(@swc/core@1.5.29(@swc/helpers@0.5.17)))
@@ -1010,6 +1013,9 @@ packages:
   '@eslint/plugin-kit@0.3.2':
     resolution: {integrity: sha512-4SaFZCNfJqvk/kenHpI8xvN42DMaoycy4PzKc5otHxRswww1kAt82OlBuwRVLofCACCTZEcla2Ydxv8scMXaTg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@goodiebag/nx-rust@3.0.0-alpha':
+    resolution: {integrity: sha512-ZdEW5PtdgJxSbNsgWyIr01dVxX7mnaVE7DLHw8srDUri2i6n+znpCqD/+LpYnmgJC82k1ncjbc8jyJbGqyqkag==}
 
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
@@ -4164,6 +4170,17 @@ snapshots:
     dependencies:
       '@eslint/core': 0.15.0
       levn: 0.4.1
+
+  '@goodiebag/nx-rust@3.0.0-alpha(nx@21.2.0(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.17))(@swc/types@0.1.23)(typescript@5.8.3))(@swc/core@1.5.29(@swc/helpers@0.5.17)))':
+    dependencies:
+      '@ltd/j-toml': 1.38.0
+      '@nx/devkit': 20.8.2(nx@21.2.0(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.17))(@swc/types@0.1.23)(typescript@5.8.3))(@swc/core@1.5.29(@swc/helpers@0.5.17)))
+      npm-run-path: 4.0.1
+      picocolors: 1.1.1
+      semver: 7.5.4
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - nx
 
   '@humanfs/core@0.19.1': {}
 


### PR DESCRIPTION
## Summary
Fixes the release workflow by configuring proper version resolvers for both JavaScript and Rust packages, ensuring NX can handle version resolution correctly for all project types.

## Changes Made

### 🔧 Release Configuration Fixes
- **Added custom generator**: Configure `@goodiebag/nx-rust:release-version` for rust-packages group
- **Version resolver strategy**: Set `currentVersionResolver: "git-tag"` with `fallbackCurrentVersionResolver: "disk"` for both groups
- **Consistent configuration**: Applied same resolver strategy to nx-plugins and rust-packages groups

### 📦 Package Version Update
- **nx-rust version**: Updated from 1.0.0 to 3.0.0 to match CHANGELOG v3.0.0 entry
- **Alignment**: Ensures package.json version matches the documented breaking changes

## Problem Solved

The previous release workflow failed because:
- **claude-code-toolkit**: NX couldn't find package.json (pure Rust project)
- **nx-rust**: No git tags existed, couldn't resolve current version
- **Missing configuration**: Release groups weren't configured to use appropriate version resolvers

## Solution

1. **Custom Generator**: rust-packages group now uses `@goodiebag/nx-rust:release-version` which handles Cargo.toml files
2. **Fallback Strategy**: Both groups use git-tag resolution with disk fallback for first releases
3. **Version Alignment**: Updated nx-rust package.json to match CHANGELOG preparation

## Expected Behavior

- **First release**: Falls back to disk version (package.json/Cargo.toml) when no git tags exist
- **Subsequent releases**: Uses git tags for version resolution
- **Rust projects**: Handled by custom nx-rust generator instead of default JavaScript generator
- **Mixed monorepo**: JavaScript packages use standard NX generator, Rust packages use nx-rust generator

## Test Plan
- [ ] CI build passes
- [ ] Release workflow can determine versions for all packages
- [ ] No package.json requirement errors for Rust projects
- [ ] Git tag fallback works correctly

🤖 Generated with [Claude Code](https://claude.ai/code)