### PR TITLE
docs: add project-specific conventional commit guidelines

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -116,3 +116,38 @@ BREAKING CHANGE: Migration interface has changed"
 - `test:` → Tests (no release)
 - `refactor:` → Code refactoring (no release)
 - `BREAKING CHANGE:` → Major version bump
+
+## Project-Specific Commit Strategy
+
+**CRITICAL**: In monorepos, make separate commits for each affected package to ensure correct semantic versioning per package.
+
+### ✅ Correct Approach - Separate Commits per Package:
+```bash
+# Commit 1: nx-rust changes (minor release justified)
+git add packages/nx-rust/
+git commit -m "feat(nx-rust): upgrade for Nx 21 compatibility and enhance README"
+
+# Commit 2: nx-surrealdb changes (patch release appropriate)  
+git add packages/nx-surrealdb/
+git commit -m "fix(nx-surrealdb): correct release command template in project.json"
+
+# Commit 3: Global changes (no package release)
+git add .github/ nx.json
+git commit -m "chore: update CI workflow and nx parallel settings"
+```
+
+### ❌ Wrong Approach - Mixed Package Changes:
+```bash
+# BAD: This causes incorrect version bumps across all packages
+git add packages/nx-rust/ packages/nx-surrealdb/ .github/ nx.json
+git commit -m "feat: enhance release workflow and prepare nx-rust v3.0.0"
+# Results in: nx-rust gets minor bump (correct) + nx-surrealdb gets minor bump (incorrect!)
+```
+
+### Scope Guidelines:
+- **Use package names as scopes**: `feat(nx-rust):`, `fix(nx-surrealdb):`, `chore(claude-code):`
+- **Separate infrastructure changes**: Use `chore:` for CI/CD, root config files
+- **Match commit type to actual change significance**:
+  - Configuration fixes → `fix:`
+  - New features → `feat:`
+  - Build/tooling updates → `chore:`


### PR DESCRIPTION
## Summary
- Add comprehensive guidelines for project-specific conventional commits in monorepos
- Prevent incorrect version bumps by requiring separate commits per package
- Include clear examples of correct vs incorrect commit approaches
- Add scope guidelines using package names

## Problem Solved
Prevents issues like the recent nx-surrealdb 0.3.0 minor bump that occurred when it should have been a patch release for a configuration fix.

## Guidelines Added
- ✅ Separate commits per package with appropriate scopes
- ✅ Match commit type to actual change significance  
- ✅ Use `feat(nx-rust):`, `fix(nx-surrealdb):` etc. for attribution
- ❌ Avoid mixed package changes in single commits

🤖 Generated with [Claude Code](https://claude.ai/code)