### PR TITLE
fix: use workspace-level dist for nx plugins to resolve package structure issues

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -112,7 +112,7 @@
         "releaseTagPattern": "{projectName}-v{version}"
       },
       "rust-packages": {
-        "projects": [],
+        "projects": ["claude-code-toolkit"],
         "version": {
           "versionActions": "@goodiebag/nx-rust/release",
           "generatorOptions": {

--- a/nx.json
+++ b/nx.json
@@ -112,7 +112,7 @@
         "releaseTagPattern": "{projectName}-v{version}"
       },
       "rust-packages": {
-        "projects": ["claude-code-toolkit"],
+        "projects": [],
         "version": {
           "versionActions": "@goodiebag/nx-rust/release",
           "generatorOptions": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "release:dry-run": "nx release --dry-run"
   },
   "devDependencies": {
-    "@goodiebag/nx-rust": "3.0.0-alpha",
+    "@goodiebag/nx-rust": "3.0.0-alpha.2",
     "@nx/esbuild": "21.2.0",
     "@nx/jest": "21.2.0",
     "@nx/js": "21.2.0",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
     "release:dry-run": "nx release --dry-run"
   },
   "devDependencies": {
-    "@goodiebag/nx-rust": "3.0.0-alpha.2",
     "@nx/esbuild": "21.2.0",
     "@nx/jest": "21.2.0",
     "@nx/js": "21.2.0",

--- a/packages/nx-rust/project.json
+++ b/packages/nx-rust/project.json
@@ -44,6 +44,7 @@
         "main": "{projectRoot}/src/index.ts",
         "tsConfig": "{projectRoot}/tsconfig.lib.json",
         "assets": [
+          "{projectRoot}/*.json",
           "{projectRoot}/*.md",
           {
             "input": "{projectRoot}/src",
@@ -54,11 +55,6 @@
             "input": "{projectRoot}/src",
             "glob": "**/*.d.ts",
             "output": "./src"
-          },
-          {
-            "input": "{projectRoot}",
-            "glob": "*.json",
-            "output": "./"
           }
         ]
       }

--- a/packages/nx-rust/project.json
+++ b/packages/nx-rust/project.json
@@ -40,26 +40,25 @@
       "outputs": ["{options.outputPath}"],
       "cache": false,
       "options": {
-        "outputPath": "{projectRoot}/dist",
+        "outputPath": "{workspaceRoot}/dist/packages/{projectName}",
         "main": "{projectRoot}/src/index.ts",
         "tsConfig": "{projectRoot}/tsconfig.lib.json",
         "assets": [
-          "{projectRoot}/*.json",
           "{projectRoot}/*.md",
           {
-            "input": "./packages/nx-rust/src",
-            "glob": "**/schema.json",
-            "output": "src"
+            "input": "{projectRoot}/src",
+            "glob": "**/!(*.ts)",
+            "output": "./src"
           },
           {
-            "input": "./packages/nx-rust/src",
-            "glob": "**/files/**",
-            "output": "src"
-          },
-          {
-            "input": "./packages/nx-rust/src",
+            "input": "{projectRoot}/src",
             "glob": "**/*.d.ts",
-            "output": "src"
+            "output": "./src"
+          },
+          {
+            "input": "{projectRoot}",
+            "glob": "*.json",
+            "output": "./"
           }
         ]
       }

--- a/packages/nx-surrealdb/project.json
+++ b/packages/nx-surrealdb/project.json
@@ -38,7 +38,7 @@
       "dependsOn": ["install"],
       "cache": true,
       "options": {
-        "outputPath": "{projectRoot}/dist",
+        "outputPath": "{workspaceRoot}/dist/packages/{projectName}",
         "main": "{projectRoot}/src/index.ts",
         "tsConfig": "{projectRoot}/tsconfig.lib.json",
         "assets": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     devDependencies:
       '@goodiebag/nx-rust':
-        specifier: 3.0.0-alpha
-        version: 3.0.0-alpha(nx@21.2.0(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.17))(@swc/types@0.1.23)(typescript@5.8.3))(@swc/core@1.5.29(@swc/helpers@0.5.17)))
+        specifier: 3.0.0-alpha.2
+        version: 3.0.0-alpha.2(nx@21.2.0(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.17))(@swc/types@0.1.23)(typescript@5.8.3))(@swc/core@1.5.29(@swc/helpers@0.5.17)))
       '@nx/esbuild':
         specifier: 21.2.0
         version: 21.2.0(@babel/traverse@7.27.4)(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.17))(@swc/types@0.1.23)(typescript@5.8.3))(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.19.12)(nx@21.2.0(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.17))(@swc/types@0.1.23)(typescript@5.8.3))(@swc/core@1.5.29(@swc/helpers@0.5.17)))
@@ -1019,6 +1019,9 @@ packages:
 
   '@goodiebag/nx-rust@3.0.0-alpha':
     resolution: {integrity: sha512-ZdEW5PtdgJxSbNsgWyIr01dVxX7mnaVE7DLHw8srDUri2i6n+znpCqD/+LpYnmgJC82k1ncjbc8jyJbGqyqkag==}
+
+  '@goodiebag/nx-rust@3.0.0-alpha.2':
+    resolution: {integrity: sha512-b4oaGbJHToDNGdW5lU7IkZvi6tGrfRIE5aL0Y9SLbgDjWSOQJQwmd5qQWYFcqXo9+6z8atvq5v5Z09bOns0cPg==}
 
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
@@ -4185,6 +4188,17 @@ snapshots:
     transitivePeerDependencies:
       - nx
 
+  '@goodiebag/nx-rust@3.0.0-alpha.2(nx@21.2.0(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.17))(@swc/types@0.1.23)(typescript@5.8.3))(@swc/core@1.5.29(@swc/helpers@0.5.17)))':
+    dependencies:
+      '@ltd/j-toml': 1.38.0
+      '@nx/devkit': 20.8.2(nx@21.2.0(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.17))(@swc/types@0.1.23)(typescript@5.8.3))(@swc/core@1.5.29(@swc/helpers@0.5.17)))
+      npm-run-path: 4.0.1
+      picocolors: 1.1.1
+      semver: 7.5.4
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - nx
+
   '@humanfs/core@0.19.1': {}
 
   '@humanfs/node@0.16.6':
@@ -6445,7 +6459,7 @@ snapshots:
     dependencies:
       hosted-git-info: 7.0.2
       proc-log: 3.0.0
-      semver: 7.7.2
+      semver: 7.5.4
       validate-npm-package-name: 5.0.1
 
   npm-run-path@4.0.1:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,9 +8,6 @@ importers:
 
   .:
     devDependencies:
-      '@goodiebag/nx-rust':
-        specifier: 3.0.0-alpha.2
-        version: 3.0.0-alpha.2(nx@21.2.0(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.17))(@swc/types@0.1.23)(typescript@5.8.3))(@swc/core@1.5.29(@swc/helpers@0.5.17)))
       '@nx/esbuild':
         specifier: 21.2.0
         version: 21.2.0(@babel/traverse@7.27.4)(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.17))(@swc/types@0.1.23)(typescript@5.8.3))(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.19.12)(nx@21.2.0(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.17))(@swc/types@0.1.23)(typescript@5.8.3))(@swc/core@1.5.29(@swc/helpers@0.5.17)))
@@ -1019,9 +1016,6 @@ packages:
 
   '@goodiebag/nx-rust@3.0.0-alpha':
     resolution: {integrity: sha512-ZdEW5PtdgJxSbNsgWyIr01dVxX7mnaVE7DLHw8srDUri2i6n+znpCqD/+LpYnmgJC82k1ncjbc8jyJbGqyqkag==}
-
-  '@goodiebag/nx-rust@3.0.0-alpha.2':
-    resolution: {integrity: sha512-b4oaGbJHToDNGdW5lU7IkZvi6tGrfRIE5aL0Y9SLbgDjWSOQJQwmd5qQWYFcqXo9+6z8atvq5v5Z09bOns0cPg==}
 
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
@@ -4178,17 +4172,6 @@ snapshots:
       levn: 0.4.1
 
   '@goodiebag/nx-rust@3.0.0-alpha(nx@21.2.0(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.17))(@swc/types@0.1.23)(typescript@5.8.3))(@swc/core@1.5.29(@swc/helpers@0.5.17)))':
-    dependencies:
-      '@ltd/j-toml': 1.38.0
-      '@nx/devkit': 20.8.2(nx@21.2.0(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.17))(@swc/types@0.1.23)(typescript@5.8.3))(@swc/core@1.5.29(@swc/helpers@0.5.17)))
-      npm-run-path: 4.0.1
-      picocolors: 1.1.1
-      semver: 7.5.4
-      tslib: 2.8.1
-    transitivePeerDependencies:
-      - nx
-
-  '@goodiebag/nx-rust@3.0.0-alpha.2(nx@21.2.0(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.17))(@swc/types@0.1.23)(typescript@5.8.3))(@swc/core@1.5.29(@swc/helpers@0.5.17)))':
     dependencies:
       '@ltd/j-toml': 1.38.0
       '@nx/devkit': 20.8.2(nx@21.2.0(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.17))(@swc/types@0.1.23)(typescript@5.8.3))(@swc/core@1.5.29(@swc/helpers@0.5.17)))


### PR DESCRIPTION
## Summary
- Fix nx-rust and nx-surrealdb to use workspace-level dist structure instead of package-level dist
- Resolve package structure issues that caused nested dist folders in published packages
- Align with gonx-style workspace dist approach for clean package publishing

## Problem Solved
Previously, our packages were building to `{projectRoot}/dist` but publishing the entire package directory, resulting in:
- Published packages with nested `dist/` folders
- Package exports pointing to `./src/index.js` but files actually in `./dist/src/index.js`
- Import resolution failures when using published packages

## Changes Made
**nx-rust:**
- Change outputPath from `{projectRoot}/dist` to `{workspaceRoot}/dist/packages/{projectName}`
- Simplify asset copying configuration with explicit `*.json` and `*.md` patterns
- Remove package-level dist folder

**nx-surrealdb:**
- Change outputPath to use workspace-level dist structure
- Keep existing asset configuration for .surql schema files and templates
- Remove package-level dist folder

## Structure Comparison
**Before (broken):**
```
packages/nx-rust/          <- Published package root
  dist/                    <- Nested dist folder ❌
    src/
    package.json
  package.json             <- main: "./src/index.js" but files in ./dist/src/ ❌
```

**After (correct):**
```
dist/packages/nx-rust/     <- Clean package for publishing
  src/                     <- Compiled files ✅
  package.json             <- main: "./src/index.js" and files are there ✅
  executors.json
```

## Test Plan
- [x] Build nx-rust successfully with new workspace dist structure
- [x] Verify clean package structure without nested dist folders
- [x] Confirm package.json exports align with actual file locations
- [ ] CI build passes
- [ ] Test published packages work correctly after release

🤖 Generated with [Claude Code](https://claude.ai/code)