### PR TITLE
fix: resolve release workflow dist/ artifact sharing issues

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,6 +63,13 @@ jobs:
       - name: Build package
         run: nx build ${{ matrix.package }}
 
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: build-${{ matrix.package }}
+          path: dist/packages/${{ matrix.package }}
+          retention-days: 1
+
   release:
     name: Release ${{ matrix.package }}
     runs-on: ubuntu-latest
@@ -86,6 +93,12 @@ jobs:
         with:
           package-group: ${{ fromJson(needs.detect.outputs.package-groups)[matrix.package] }}
           package-name: ${{ matrix.package }}
+
+      - name: Download build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: build-${{ matrix.package }}
+          path: dist/packages/${{ matrix.package }}
 
       - name: Configure git
         run: |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,8 @@
 # CLAUDE.md
 
+# conversations
+- stop saying the user is right about everything . always analyze independently and then say what you think is right. three is no issue if your analysis is different from the user's. always explain your reasoning.
+
 ## Environment
 
 - we are running on WSL, so avoid trying to open GUI browsers. Use headless


### PR DESCRIPTION
## Summary

Fixes both major release workflow issues:

1. **ENOENT errors**: Build artifacts weren't shared between build and release jobs
2. **Missing git push**: Custom Rust version actions weren't pushing commits/tags to remote

## Changes

### Fix 1: Build Artifacts Sharing
- **Add build artifacts upload**: Each build job uploads its `dist/packages/{package}` as an artifact
- **Add build artifacts download**: Each release job downloads the corresponding artifact before publishing
- **Package-specific naming**: Uses `build-{package}` naming to avoid conflicts between matrix jobs
- **Short retention**: 1-day retention since artifacts are only needed during workflow execution

### Fix 2: Git Push for Rust Packages  
- **Import gitPush**: Added import from NX's release utilities to nx-rust plugin
- **Add git push logic**: Added `gitPush()` call to `afterAllProjectsVersioned` function
- **Use --follow-tags**: Leverages NX's native `gitPush` which automatically pushes both commits and tags
- **Proper error handling**: Logs warnings but doesn't break release process
- **Dry-run support**: Respects dry-run flag for testing

## Problems Solved

### Before Fix 1:
- Build job (Runner A): Creates `dist/packages/{package}/` files
- Release job (Runner B): Tries to access files that don't exist → `ENOENT: no such file or directory`

### Before Fix 2:  
- claude-code-toolkit: Version updates and tags created locally but never pushed to remote
- docs.rs showing outdated info because repository tags weren't updated
- GitHub releases not created because tags weren't on remote

### After Both Fixes:
- ✅ Build artifacts properly shared between jobs via GitHub Actions artifacts  
- ✅ All packages (goodiebag, nx-rust, nx-surrealdb, claude-code-toolkit) should publish without errors
- ✅ Rust packages push commits and tags to remote repository
- ✅ Documentation sites and GitHub releases work correctly

## Test Plan

- [ ] Build jobs upload artifacts successfully  
- [ ] Release jobs download artifacts and find required package.json files
- [ ] All JS packages publish without ENOENT errors
- [ ] Rust packages push commits and tags to remote after release
- [ ] docs.rs updates with correct repository tags
- [ ] GitHub releases created properly

Ready for comprehensive workflow testing\!