### PR TITLE
fix(nx-rust): reset version to match git tag

### DIFF
--- a/packages/nx-rust/package.json
+++ b/packages/nx-rust/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@goodiebag/nx-rust",
-  "version": "3.1.0",
+  "version": "3.0.2",
   "main": "./src/index.js",
   "exports": {
     ".": "./src/index.js",


### PR DESCRIPTION
## Summary
Reset nx-rust version from 3.1.0 back to 3.0.2 to match the latest git tag.

## Problem
- package.json had version 3.1.0  
- Latest git tag was nx-rust@3.0.2
- This mismatch caused empty release PRs since NX detected no version change needed

## Solution
Reset to 3.0.2 so the release system can properly increment to 3.1.0 with file changes.

## Test plan
- [x] After merge, watch prepare workflow create proper release PR with actual changes