### PR TITLE
docs: add git switcher reference and format fixes

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Global code owner - all files require review from wizardsupreme
+* @wizardsupreme

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,0 @@
-# Global code owner - all files require review from wizardsupreme
-* @wizardsupreme

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
 
           # Extract package name and version from commit message
           EXTRACT_RESULT=$(echo "$COMMIT_MESSAGE" | sed -n 's/.*for \([^@]*\)@\([0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*\).*/\1|\2/p')
-          
+
           if [ -n "$EXTRACT_RESULT" ]; then
             PACKAGE_NAME=$(echo "$EXTRACT_RESULT" | cut -d'|' -f1)
             VERSION=$(echo "$EXTRACT_RESULT" | cut -d'|' -f2)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
           # Expected format: "🚀 Release Request for package-name@version - ..."
           COMMIT_MESSAGE=$(git log -1 --pretty=format:"%s")
           echo "📝 Commit message: $COMMIT_MESSAGE"
-          
+
           # Extract package name and version from commit message
           EXTRACT_RESULT=$(echo "$COMMIT_MESSAGE" | sed -n 's/.*for \([^@]*\)@\([0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*\).*/\1|\2/p')
           

--- a/docs/cool-tools/cool-tools.md
+++ b/docs/cool-tools/cool-tools.md
@@ -9,3 +9,5 @@ https://llm.datasette.io/en/stable/index.html
 https://github.com/JamesIves/github-pages-deploy-action
 
 https://github.com/squidfunk/mkdocs-material - make documentatiovns
+
+https://github.com/TheYkk/git-switcher - git switcher


### PR DESCRIPTION
## Summary
- Add git-switcher tool reference to cool-tools.md for easy git identity switching
- Apply format fixes

## Changes
- Document git-switcher tool for managing multiple git identities
- Format improvements

## Test plan
- [x] Documentation is clear and useful
- [x] Format changes don't break anything