### PR TITLE
fix: auto-stage formatting changes in pre-commit hook

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -64,3 +64,6 @@ fi
 
 # Format affected files with NX
 nx format:write --uncommitted
+
+# Stage any formatting changes
+git add .

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,10 +1,15 @@
 # CLAUDE.md
 
 # conversations
-- stop saying the user is right about everything . always analyze independently and then say what you think is right. three is no issue if your analysis is different from the user's. always explain your reasoning.
+
+- stop saying the user is right about everything . always analyze independently
+  and then say what you think is right. three is no issue if your analysis is
+  different from the user's. always explain your reasoning.
 
 ## Git Safety Rules
-- **ALWAYS ask explicit permission before any git checkout, git switch, or branch creation**
+
+- **ALWAYS ask explicit permission before any git checkout, git switch, or
+  branch creation**
 - Explain why branch switch is needed before requesting permission
 - Wait for user confirmation before proceeding with branch operations
 
@@ -20,7 +25,8 @@
 
 ## Automated Workflow
 
-Husky handles formatting, commit validation, lockfile sync, and security checks automatically.
+Husky handles formatting, commit validation, lockfile sync, and security checks
+automatically.
 
 ## Package Manager Preference
 
@@ -61,7 +67,8 @@ development.
 
 ## Release Process
 
-GitHub Actions workflow: PR merge → prepare release → merge release PR → publish.
+GitHub Actions workflow: PR merge → prepare release → merge release PR →
+publish.
 
 ### Automatic Release Features:
 
@@ -76,14 +83,16 @@ GitHub Actions workflow: PR merge → prepare release → merge release PR → p
 
 ## Git Strategy - Merge Policy
 
-**IMPORTANT**: When merging PRs, always use **regular merge** instead of squash merge.
+**IMPORTANT**: When merging PRs, always use **regular merge** instead of squash
+merge.
 
-- ✅ **Use**: "Create a merge commit" option  
+- ✅ **Use**: "Create a merge commit" option
 - ❌ **NEVER use**: "Squash and merge" option
 
 **Why Regular Merges?**
+
 - **Preserves conventional commit history** for accurate semantic versioning
-- **Enables per-package version detection** by NX release automation  
+- **Enables per-package version detection** by NX release automation
 - **Maintains granular audit trail** of individual changes
 - **Prevents version detection issues** caused by collapsed commits
 
@@ -105,8 +114,8 @@ GitHub Actions workflow: PR merge → prepare release → merge release PR → p
 
 ## Conventional Commits
 
-Use format: `type: description` or `type(scope): description`
-Types: feat, fix, chore, docs, test, refactor
+Use format: `type: description` or `type(scope): description` Types: feat, fix,
+chore, docs, test, refactor
 
 ## Project-Specific Commit Strategy
 


### PR DESCRIPTION
## Summary
- Fixes issue where NX formatting changes were left uncommitted after push
- Adds `git add .` after `nx format:write --uncommitted` in pre-commit hook
- Includes previously unstaged formatting changes to CLAUDE.md

## Problem
The pre-commit hook was running `nx format:write --uncommitted` but not staging the formatted files, leaving uncommitted changes after push operations.

## Solution
Added automatic staging of formatted files to ensure they're included in the commit.

## Test plan
- Verify pre-commit hook now includes formatting changes in commits
- Check that no formatting changes are left uncommitted after push