### PR TITLE
fix: remove duplicate PR triggers from worker workflows

### DIFF
--- a/.github/workflows/create-release-prs.yml
+++ b/.github/workflows/create-release-prs.yml
@@ -5,11 +5,6 @@ permissions:
   pull-requests: write
 
 on:
-  pull_request:
-    types: [closed]
-    branches:
-      - main
-      - '!release/**'
   workflow_dispatch:
     inputs:
       # For manual execution
@@ -54,8 +49,6 @@ jobs:
   detect:
     name: Detect
     runs-on: ubuntu-latest
-    # Skip if it's a release PR merge (only for PR triggers, not manual)
-    if: github.event_name == 'workflow_dispatch' || (github.event.pull_request.merged == true && !startsWith(github.event.pull_request.head.ref, 'release/'))
     outputs:
       has-packages: ${{ steps.detect.outputs.has-packages }}
       packages: ${{ steps.detect.outputs.packages }}

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -1,9 +1,6 @@
 name: 🚀 Publish Packages
 
 on:
-  pull_request:
-    types: [closed]
-    branches: [main]
   workflow_dispatch:
     inputs:
       pr_number:
@@ -27,8 +24,6 @@ jobs:
   release:
     name: Tag and Publish
     runs-on: ubuntu-latest
-    # Only run if PR was merged and came from a release/* branch
-    if: github.event.pull_request.merged == true && startsWith(github.event.pull_request.head.ref, 'release/')
 
     steps:
       - name: Checkout repository
@@ -107,16 +102,3 @@ jobs:
           echo "🧹 Deleting release branch: $BRANCH_NAME"
           git push origin --delete "$BRANCH_NAME" || echo "ℹ️ Branch $BRANCH_NAME already deleted or doesn't exist"
           echo "✅ Release branch cleanup completed"
-
-  no-release:
-    name: No release detected
-    runs-on: ubuntu-latest
-    if: github.event.pull_request.merged != true || !startsWith(github.event.pull_request.head.ref, 'release/')
-
-    steps:
-      - name: Skip release
-        run: |
-          echo "ℹ️ PR detected but not a merged release branch PR."
-          echo "PR merged: ${{ github.event.pull_request.merged }}"
-          echo "Head ref: ${{ github.event.pull_request.head.ref }}"
-          echo "No release actions will be performed."


### PR DESCRIPTION
This PR fixes the duplicate workflow runs by implementing pure dispatcher architecture.

## Problem
When a PR was merged, workflows were running twice:
1. Direct `pull_request: [closed]` trigger in worker workflows
2. Indirect `workflow_dispatch` trigger from dispatcher workflows

## Solution
- **Removed `pull_request` triggers** from worker workflows:
  - `create-release-prs.yml`
  - `publish-packages.yml`
- **Kept `pull_request` triggers** only in dispatcher workflows:
  - `on-pr-opened.yml`
  - `on-pr-merged.yml`
- **Removed unnecessary `if` conditions** since workflows now only have one trigger type
- **Removed obsolete `no-release` job** that referenced non-existent PR context

## Architecture
- **Dispatcher workflows**: Handle PR events and route to appropriate workers
- **Worker workflows**: Only triggered via `workflow_dispatch` (no direct PR triggers)

This ensures each merge only triggers one workflow run per worker, eliminating duplicates.