### PR TITLE
fix(ci): reorganize debug output in detect-affected action

### DIFF
--- a/.github/actions/detect-affected/action.yml
+++ b/.github/actions/detect-affected/action.yml
@@ -77,11 +77,7 @@ runs:
           LINT_PACKAGES=$(nx show projects --affected --with-target lint --json || echo '[]')
           TEST_PACKAGES=$(nx show projects --affected --with-target test --json || echo '[]')
           BUILD_PACKAGES=$(nx show projects --affected --with-target build --json || echo '[]')
-          
-          echo "🔍 Lint packages: $LINT_PACKAGES"
-          echo "🧪 Test packages: $TEST_PACKAGES"
-          echo "🏗️ Build packages: $BUILD_PACKAGES"
-          
+
           echo "lint-packages=$LINT_PACKAGES" >> $GITHUB_OUTPUT
           echo "has-lint-packages=$([ $(echo $LINT_PACKAGES | jq length) -gt 0 ] && echo 'true' || echo 'false')" >> $GITHUB_OUTPUT
           echo "test-packages=$TEST_PACKAGES" >> $GITHUB_OUTPUT
@@ -120,4 +116,9 @@ runs:
           echo "🎯 Found $PACKAGE_COUNT affected packages"
           echo "📋 Packages: $AFFECTED"
           echo "🏷️ Package groups: $PACKAGE_GROUPS"
+          
+          echo "🔍 Lint packages: $LINT_PACKAGES"
+          echo "🧪 Test packages: $TEST_PACKAGES"
+          echo "🏗️ Build packages: $BUILD_PACKAGES"
+          
         fi


### PR DESCRIPTION
## Summary
• Reorganized debug output in the detect-affected GitHub Action to improve CI visibility
• Moved debug logs (lint, test, build packages) to the end of the action after the summary
• Maintains all existing functionality while improving log readability

## Test plan
- [x] Verify action.yml syntax is valid
- [ ] Test CI workflow runs successfully with reorganized output
- [ ] Confirm debug information is still displayed correctly