### PR TITLE
chore: update nx-surrealdb dependency to v0.4.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "install:dotfiles": "cd dotfiles && ./install.sh"
   },
   "devDependencies": {
-    "@deepbrainspace/nx-surrealdb": "0.4.0",
+    "@deepbrainspace/nx-surrealdb": "0.4.1",
     "@goodiebag/nx-rust": "3.1.0",
     "@goodiebag/nx-toolkit": "0.2.0",
     "@nx/esbuild": "21.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,8 +18,8 @@ importers:
         version: 1.3.2(tslib@2.8.1)(typescript@5.8.3)(ws@8.18.2)
     devDependencies:
       '@deepbrainspace/nx-surrealdb':
-        specifier: 0.4.0
-        version: 0.4.0(nx@21.2.1(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.17))(@swc/types@0.1.23)(typescript@5.8.3))(@swc/core@1.5.29(@swc/helpers@0.5.17)))(typescript@5.8.3)(ws@8.18.2)
+        specifier: 0.4.1
+        version: 0.4.1(nx@21.2.1(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.17))(@swc/types@0.1.23)(typescript@5.8.3))(@swc/core@1.5.29(@swc/helpers@0.5.17)))(typescript@5.8.3)(ws@8.18.2)
       '@goodiebag/nx-rust':
         specifier: 3.1.0
         version: 3.1.0(nx@21.2.1(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.17))(@swc/types@0.1.23)(typescript@5.8.3))(@swc/core@1.5.29(@swc/helpers@0.5.17)))
@@ -1190,10 +1190,10 @@ packages:
       }
     engines: { node: '>=12' }
 
-  '@deepbrainspace/nx-surrealdb@0.4.0':
+  '@deepbrainspace/nx-surrealdb@0.4.1':
     resolution:
       {
-        integrity: sha512-asupMJ1ciTsJWQLuJaek+Hu5/8uf/wkH895vVg6SWyhLSd9oNPniXt8GhUkfres8PXN9gvgmII8WJLOmTXYmxQ==,
+        integrity: sha512-FMAm+D0x+s7LewMT25xYuOBQBXSqwL/Hr5nN+77UOu6NeLRU2CwKm4crqkphTpA1DLUvJ8OcQ4aJaWAou0IuUw==,
       }
 
   '@emnapi/core@1.4.3':
@@ -6281,7 +6281,7 @@ snapshots:
     dependencies:
       '@jridgewell/trace-mapping': 0.3.9
 
-  '@deepbrainspace/nx-surrealdb@0.4.0(nx@21.2.1(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.17))(@swc/types@0.1.23)(typescript@5.8.3))(@swc/core@1.5.29(@swc/helpers@0.5.17)))(typescript@5.8.3)(ws@8.18.2)':
+  '@deepbrainspace/nx-surrealdb@0.4.1(nx@21.2.1(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.17))(@swc/types@0.1.23)(typescript@5.8.3))(@swc/core@1.5.29(@swc/helpers@0.5.17)))(typescript@5.8.3)(ws@8.18.2)':
     dependencies:
       '@nx/devkit': 21.2.1(nx@21.2.1(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.17))(@swc/types@0.1.23)(typescript@5.8.3))(@swc/core@1.5.29(@swc/helpers@0.5.17)))
       dotenv: 16.5.0


### PR DESCRIPTION
Updates the monorepo dependency to use the newly released nx-surrealdb v0.4.1